### PR TITLE
Ability to pass ssl_context_options for use self-signed SSL certificates.

### DIFF
--- a/src/Protocol/Imap.php
+++ b/src/Protocol/Imap.php
@@ -59,10 +59,11 @@ class Imap
      * @param  string      $host  hostname or IP address of IMAP server
      * @param  int|null    $port  of IMAP server, default is 143 (993 for ssl)
      * @param  string|bool $ssl   use 'SSL', 'TLS' or false
+     * @param  array $ssl_context_options options, passed to stream_context_create()
      * @throws Exception\RuntimeException
      * @return string welcome message
      */
-    public function connect($host, $port = null, $ssl = false)
+    public function connect($host, $port = null, $ssl = false, $ssl_context_options = [])
     {
         $isTls = false;
 
@@ -87,7 +88,15 @@ class Imap
         }
 
         ErrorHandler::start();
-        $this->socket = fsockopen($host, $port, $errno, $errstr, self::TIMEOUT_CONNECTION);
+        $context = stream_context_create($ssl_context_options);
+        $this->socket = stream_socket_client(
+            $host.':'.$port,
+            $errno,
+            $errstr,
+            self::TIMEOUT_CONNECTION,
+            STREAM_CLIENT_CONNECT,
+            $context
+        );
         $error = ErrorHandler::stop();
         if (!$this->socket) {
             throw new Exception\RuntimeException(sprintf(

--- a/src/Storage/Imap.php
+++ b/src/Storage/Imap.php
@@ -167,6 +167,7 @@ class Imap extends AbstractStorage implements Folder\FolderInterface, Writable\W
      *   - password password for user 'username' [optional, default = '']
      *   - port port for IMAP server [optional, default = 110]
      *   - ssl 'SSL' or 'TLS' for secure sockets
+     *   - ssl_context_options Options passed to stream_context_create()
      *   - folder select this folder [optional, default = 'INBOX']
      *
      * @param  array $params mail reader specific parameters
@@ -200,9 +201,10 @@ class Imap extends AbstractStorage implements Folder\FolderInterface, Writable\W
         $password = isset($params->password) ? $params->password : '';
         $port     = isset($params->port)     ? $params->port     : null;
         $ssl      = isset($params->ssl)      ? $params->ssl      : false;
+        $ssl_context_options = isset($params->ssl_context_options) ? $params->ssl_context_options: [];
 
         $this->protocol = new Protocol\Imap();
-        $this->protocol->connect($host, $port, $ssl);
+        $this->protocol->connect($host, $port, $ssl, $ssl_context_options);
         if (!$this->protocol->login($params->user, $password)) {
             throw new Exception\RuntimeException('cannot login, user or password wrong');
         }


### PR DESCRIPTION
For correct working with self-signed sertificates use this:
```
[
    'ssl' => [
         'verify_peer' => true,
         'verify_peer_name' => false,
         'allow_self_signed' => true
     ]
]

```